### PR TITLE
Run clippy lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,21 +28,15 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
-  # clippy-lints:
-  #   name: Clippy lints
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@nightly
-  #       with:
-  #         components: clippy
-  #     - uses: Swatinem/rust-cache@v2
-  #     - name: Run lints
-  #       env:
-  #         RUSTFLAGS: -C debuginfo=0
-  #       run: |
-  #         cargo clippy --all-features
-  #         cargo clippy -- -D warnings
+  clippy-lints:
+    name: Clippy lints
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D clippy::pedantic
 
   format:
     name: Formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["crates/*"]
+resolver = "3"

--- a/crates/tsql_parser/src/lib.rs
+++ b/crates/tsql_parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::cmp::Ordering;
 
 /// An experimental TSQL [`Parser`].
@@ -24,7 +26,7 @@ impl Parser<'_> {
         let mut tokens = Vec::new();
 
         while let Some(token) = self.lexer.next_token() {
-            tokens.push(token)
+            tokens.push(token);
         }
 
         tokens
@@ -135,7 +137,7 @@ impl Lexer<'_> {
     /// Advance the cursor by some `n` positions.
     fn advance(&mut self, n: usize) {
         self.prev_cursor = self.cursor;
-        self.cursor += n
+        self.cursor += n;
     }
 
     fn skip_whitespace(&mut self) {
@@ -157,9 +159,8 @@ impl Lexer<'_> {
         while let Some(ch) = self.current() {
             if ch.is_whitespace() || !ch.is_ascii() || ch == c {
                 break;
-            } else {
-                self.advance(1);
             }
+            self.advance(1);
         }
 
         Token {
@@ -172,7 +173,7 @@ impl Lexer<'_> {
         let start = self.cursor;
 
         if self.current().is_some_and(|it| matches!(it, '-' | '+')) {
-            self.advance(1)
+            self.advance(1);
         }
 
         let mut has_decimal_point = false;
@@ -181,11 +182,11 @@ impl Lexer<'_> {
             if ch.is_numeric() {
                 self.advance(1);
             } else if ch == '.' {
-                if !has_decimal_point {
+                if has_decimal_point {
+                    unimplemented!()
+                } else {
                     has_decimal_point = true;
                     self.advance(1);
-                } else {
-                    unimplemented!()
                 }
             } else {
                 break;
@@ -220,11 +221,10 @@ impl Lexer<'_> {
         let start = self.cursor;
 
         while let Some(ch) = self.current() {
-            if ch != '\'' {
-                self.advance(1);
-            } else {
+            if ch == '\'' {
                 break;
             }
+            self.advance(1);
         }
 
         let end = self.cursor;
@@ -343,5 +343,5 @@ fn test_parse_tokens() {
                 value: Some(TokenValue::String("string".into()))
             },
         ],
-    )
+    );
 }


### PR DESCRIPTION
I followed official docs (stable version) for CI: https://doc.rust-lang.org/clippy/continuous_integration/github_actions.html

I prefer a more strict version: `cargo clippy -- -D clippy::pedantic`, so I combined them.

Also, I updated Cargo.toml to avoid: warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2024 which implies `resolver = "3"`