### PR TITLE
Support statements tokens

### DIFF
--- a/crates/tsql_parser/src/lib.rs
+++ b/crates/tsql_parser/src/lib.rs
@@ -63,6 +63,9 @@ impl Lexer<'_> {
             Some('=') => Some(self.eat(TokenKind::Eq)),
             Some('*') => Some(self.eat(TokenKind::Star)),
             Some(';') => Some(self.eat(TokenKind::Semicolon)),
+            Some(',') => Some(self.eat(TokenKind::Comma)),
+            Some('.') => Some(self.eat(TokenKind::Dot)),
+            Some('@') => Some(self.eat(TokenKind::At)),
             Some('!') => {
                 if self.peek().is_some_and(|it| it == '=') {
                     Some(self.eat(TokenKind::NotEq))
@@ -90,13 +93,10 @@ impl Lexer<'_> {
             }
             Some('[') => Some(self.eat(TokenKind::LeftSqBracket)),
             Some(']') => Some(self.eat(TokenKind::RightSqBracket)),
-            Some(ch) if ch.is_ascii() => {
-                if self.prev() == '[' {
-                    Some(self.lex_ascii_until(']'))
-                } else {
-                    Some(self.lex_ascii_until(';'))
-                }
-            }
+            Some('(') => Some(self.eat(TokenKind::LeftParen)),
+            Some(')') => Some(self.eat(TokenKind::RightParen)),
+            Some(ch) if ch.is_identifier_start() => Some(self.lex_identifier()),
+            Some(ch) if ch.is_ascii_digit() => Some(self.lex_number()),
             Some(_) => unimplemented!(),
             None => None,
         }
@@ -126,7 +126,12 @@ impl Lexer<'_> {
             | TokenKind::LessThan
             | TokenKind::GreaterThan
             | TokenKind::LeftSqBracket
-            | TokenKind::RightSqBracket => self.advance(1),
+            | TokenKind::RightSqBracket
+            | TokenKind::LeftParen
+            | TokenKind::RightParen
+            | TokenKind::Comma
+            | TokenKind::Dot
+            | TokenKind::At => self.advance(1),
             TokenKind::LessThanEq | TokenKind::GreaterThanEq | TokenKind::NotEq => self.advance(2),
             _ => panic!("cannot eat kind"),
         }
@@ -146,26 +151,6 @@ impl Lexer<'_> {
                 ' ' | '\t' | '\\' | '\r' | '\n' => self.advance(ch.len_utf8()),
                 _ => break,
             }
-        }
-    }
-
-    fn lex_ascii_until(&mut self, c: char) -> Token {
-        if self.current().is_some_and(char::is_numeric) {
-            return self.lex_number();
-        }
-
-        let start = self.cursor;
-
-        while let Some(ch) = self.current() {
-            if ch.is_whitespace() || !ch.is_ascii() || ch == c {
-                break;
-            }
-            self.advance(1);
-        }
-
-        Token {
-            kind: TokenKind::Word,
-            value: Some(TokenValue::Word(self.source[start..self.cursor].into())),
         }
     }
 
@@ -237,6 +222,29 @@ impl Lexer<'_> {
             value: Some(TokenValue::String(self.source[start..end].into())),
         }
     }
+
+    fn lex_identifier(&mut self) -> Token {
+        let start = self.cursor;
+        while let Some(ch) = self.current() {
+            if !ch.is_identifier_continue() {
+                break;
+            }
+            self.advance(1);
+        }
+
+        let identifier = &self.source[start..self.cursor];
+        if let Some(keyword) = lookup_keyword(identifier) {
+            return Token {
+                kind: TokenKind::Keyword(keyword),
+                value: None,
+            };
+        }
+
+        Token {
+            kind: TokenKind::Word,
+            value: Some(TokenValue::Word(identifier.into())),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -247,6 +255,7 @@ struct Token {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TokenKind {
+    Keyword(Keyword),
     Word,
     Star,
     Semicolon,
@@ -262,6 +271,47 @@ enum TokenKind {
     LeftSqBracket,
     RightSqBracket,
     NotEq,
+    LeftParen,
+    RightParen,
+    Comma,
+    Dot,
+    At,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Keyword {
+    Select,
+    From,
+    Where,
+    And,
+    Join,
+    Right,
+    Left,
+    As,
+    On,
+    In,
+    Count,
+    Distinct,
+}
+
+/// Checks if a string is a keyword, ignoring case.
+#[must_use]
+pub fn lookup_keyword(s: &str) -> Option<Keyword> {
+    match s.to_ascii_uppercase().as_str() {
+        "SELECT" => Some(Keyword::Select),
+        "FROM" => Some(Keyword::From),
+        "WHERE" => Some(Keyword::Where),
+        "AND" => Some(Keyword::And),
+        "JOIN" => Some(Keyword::Join),
+        "RIGHT" => Some(Keyword::Right),
+        "LEFT" => Some(Keyword::Left),
+        "AS" => Some(Keyword::As),
+        "ON" => Some(Keyword::On),
+        "IN" => Some(Keyword::In),
+        "COUNT" => Some(Keyword::Count),
+        "DISTINCT" => Some(Keyword::Distinct),
+        _ => None,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -286,62 +336,296 @@ impl Ord for TokenValue {
     }
 }
 
-#[test]
-fn test_parse_tokens() {
-    let source = "\n\n\n[word]   \n 1 -1.0 > >= <=\n\n\t< = != \r'string'";
-    let tokens = Parser::new(source).parse();
+pub trait CharExt {
+    /// true if this char is a valid start of an identifier (ASCII letter or `_`)
+    fn is_identifier_start(&self) -> bool;
+    /// true if this char is a valid continuation of an identifier (ASCII letter, digit, or `_`)
+    fn is_identifier_continue(&self) -> bool;
+}
 
-    assert_eq!(
-        tokens,
-        vec![
-            Token {
-                kind: TokenKind::LeftSqBracket,
-                value: None
-            },
-            Token {
-                kind: TokenKind::Word,
-                value: Some(TokenValue::Word("word".into()))
-            },
-            Token {
-                kind: TokenKind::RightSqBracket,
-                value: None
-            },
-            Token {
-                kind: TokenKind::Int,
-                value: Some(TokenValue::Int(1))
-            },
-            Token {
-                kind: TokenKind::Float,
-                value: Some(TokenValue::Float(-1.0))
-            },
-            Token {
-                kind: TokenKind::GreaterThan,
-                value: None
-            },
-            Token {
-                kind: TokenKind::GreaterThanEq,
-                value: None
-            },
-            Token {
-                kind: TokenKind::LessThanEq,
-                value: None
-            },
-            Token {
-                kind: TokenKind::LessThan,
-                value: None
-            },
-            Token {
-                kind: TokenKind::Eq,
-                value: None
-            },
-            Token {
-                kind: TokenKind::NotEq,
-                value: None
-            },
-            Token {
-                kind: TokenKind::String,
-                value: Some(TokenValue::String("string".into()))
-            },
-        ],
-    );
+impl CharExt for char {
+    #[inline]
+    fn is_identifier_start(&self) -> bool {
+        self.is_ascii_alphabetic() || *self == '_'
+    }
+
+    #[inline]
+    fn is_identifier_continue(&self) -> bool {
+        self.is_ascii_alphanumeric() || *self == '_'
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::too_many_lines)]
+    #[test]
+    fn test_parse_tokens() {
+        // Import variants to make the assertion more concise.
+        use super::Keyword::*;
+        use super::TokenKind::*;
+
+        let source = r"
+            select
+                'literal',
+                [column1],
+                column2 as alias1,
+                count(distinct column3) as alias2
+            from table1
+            join table2 on (table1.id = table2.id)
+            left join table3 on (table2.id = table3.id)
+            where
+                table1.column1 = 'string'
+                and table2.column1 in (@variable1)
+        ";
+
+        let tokens = Parser::new(source).parse();
+
+        assert_eq!(
+            tokens,
+            vec![
+                Token {
+                    kind: Keyword(Select),
+                    value: None
+                },
+                Token {
+                    kind: String,
+                    value: Some(TokenValue::String("literal".into()))
+                },
+                Token {
+                    kind: Comma,
+                    value: None
+                },
+                Token {
+                    kind: LeftSqBracket,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("column1".into()))
+                },
+                Token {
+                    kind: RightSqBracket,
+                    value: None
+                },
+                Token {
+                    kind: Comma,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("column2".into()))
+                },
+                Token {
+                    kind: Keyword(As),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("alias1".into()))
+                },
+                Token {
+                    kind: Comma,
+                    value: None
+                },
+                Token {
+                    kind: Keyword(Count),
+                    value: None
+                },
+                Token {
+                    kind: LeftParen,
+                    value: None
+                },
+                Token {
+                    kind: Keyword(Distinct),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("column3".into()))
+                },
+                Token {
+                    kind: RightParen,
+                    value: None
+                },
+                Token {
+                    kind: Keyword(As),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("alias2".into()))
+                },
+                Token {
+                    kind: Keyword(From),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table1".into()))
+                },
+                Token {
+                    kind: Keyword(Join),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table2".into()))
+                },
+                Token {
+                    kind: Keyword(On),
+                    value: None
+                },
+                Token {
+                    kind: LeftParen,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table1".into()))
+                },
+                Token {
+                    kind: Dot,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("id".into()))
+                },
+                Token {
+                    kind: Eq,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table2".into()))
+                },
+                Token {
+                    kind: Dot,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("id".into()))
+                },
+                Token {
+                    kind: RightParen,
+                    value: None
+                },
+                Token {
+                    kind: Keyword(Left),
+                    value: None
+                },
+                Token {
+                    kind: Keyword(Join),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table3".into()))
+                },
+                Token {
+                    kind: Keyword(On),
+                    value: None
+                },
+                Token {
+                    kind: LeftParen,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table2".into()))
+                },
+                Token {
+                    kind: Dot,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("id".into()))
+                },
+                Token {
+                    kind: Eq,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table3".into()))
+                },
+                Token {
+                    kind: Dot,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("id".into()))
+                },
+                Token {
+                    kind: RightParen,
+                    value: None
+                },
+                Token {
+                    kind: Keyword(Where),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table1".into()))
+                },
+                Token {
+                    kind: Dot,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("column1".into()))
+                },
+                Token {
+                    kind: Eq,
+                    value: None
+                },
+                Token {
+                    kind: String,
+                    value: Some(TokenValue::String("string".into()))
+                },
+                Token {
+                    kind: Keyword(And),
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("table2".into()))
+                },
+                Token {
+                    kind: Dot,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("column1".into()))
+                },
+                Token {
+                    kind: Keyword(In),
+                    value: None
+                },
+                Token {
+                    kind: LeftParen,
+                    value: None
+                },
+                Token {
+                    kind: At,
+                    value: None
+                },
+                Token {
+                    kind: Word,
+                    value: Some(TokenValue::Word("variable1".into()))
+                },
+                Token {
+                    kind: RightParen,
+                    value: None
+                },
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Support simple SQL statements while keeping the core logic. 

Update lexer to properly recognize SQL keywords (`SELECT`, `FROM`, etc.), identifiers, and other common syntax like `()`, `,`, `.`, and `@`.

cc #4